### PR TITLE
[38][Chore] Setup Data Layer

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,6 +24,7 @@ target 'SurveyApp' do
   pod 'R.swift'
   pod 'SwiftLint'
   pod 'AlamofireNetworkActivityLogger', '~> 3.4'
+  pod 'KeychainAccess'
   
   pod 'Crashlytics'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,6 +5,7 @@ PODS:
   - Crashlytics (3.14.0):
     - Fabric (~> 1.10.2)
   - Fabric (1.10.2)
+  - KeychainAccess (4.2.2)
   - Keys (1.0.1)
   - Nimble (9.2.0)
   - NimbleExtension (0.1.0)
@@ -33,6 +34,7 @@ DEPENDENCIES:
   - Alamofire
   - AlamofireNetworkActivityLogger (~> 3.4)
   - Crashlytics
+  - KeychainAccess
   - Keys (from `Pods/CocoaPodsKeys`)
   - Nimble
   - NimbleExtension (from `https://github.com/nimblehq/NimbleExtension`, branch `master`)
@@ -49,6 +51,7 @@ SPEC REPOS:
     - AlamofireNetworkActivityLogger
     - Crashlytics
     - Fabric
+    - KeychainAccess
     - Nimble
     - OHHTTPStubs
     - Quick
@@ -75,6 +78,7 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityLogger: 162ab8aee00e6267a4304d7cc134e13ccfe3bcc5
   Crashlytics: 9220f5bc89e7a618df411b4f639389dbfb0e03d2
   Fabric: ea977e3cd9c20425516d3dafd3bf8c941c51223f
+  KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   NimbleExtension: acad4290f27afd4241b1ea20f8597889085e2ce7
@@ -86,6 +90,6 @@ SPEC CHECKSUMS:
   Sourcery: 43d8addc35ca31c2ab331cfd34b02421fa53bb7f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 0393bd6587f16d4181a30d012511f5c738ac88c9
+PODFILE CHECKSUM: 2c3f86ed0fbecc612fd9bfc2ecf156ffcbb8793d
 
 COCOAPODS: 1.10.1

--- a/SurveyApp.xcodeproj/project.pbxproj
+++ b/SurveyApp.xcodeproj/project.pbxproj
@@ -22,6 +22,11 @@
 		843AB4DA266DCB5E00EC3F28 /* LoginInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843AB4D5266DCB5E00EC3F28 /* LoginInteractor.swift */; };
 		843AB4DB266DCB5E00EC3F28 /* LoginPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843AB4D6266DCB5E00EC3F28 /* LoginPresenter.swift */; };
 		843AB5FB266E2AAE00EC3F28 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 843AB5FA266E2AAE00EC3F28 /* .swiftlint.yml */; };
+		8448C23A2679F9F4005955D4 /* UserCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8448C2392679F9F4005955D4 /* UserCredential.swift */; };
+		8448C23D2679FA90005955D4 /* KeychainStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8448C23C2679FA90005955D4 /* KeychainStorage.swift */; };
+		8448C23F2679FA97005955D4 /* KeychainKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8448C23E2679FA97005955D4 /* KeychainKeys.swift */; };
+		8448C2412679FAFF005955D4 /* UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8448C2402679FAFF005955D4 /* UserSession.swift */; };
+		8448C2432679FB1E005955D4 /* UserSessionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8448C2422679FB1E005955D4 /* UserSessionProvider.swift */; };
 		84648400267757D100233656 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846483FF267757D100233656 /* ErrorView.swift */; };
 		84A0AB5F26706AC4005EBF9A /* CredentialTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0AB5E26706AC4005EBF9A /* CredentialTextField.swift */; };
 		84A0AB6526708954005EBF9A /* R.swift+Typealias.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0AB6426708954005EBF9A /* R.swift+Typealias.swift */; };
@@ -90,6 +95,11 @@
 		843AB4D6266DCB5E00EC3F28 /* LoginPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPresenter.swift; sourceTree = "<group>"; };
 		843AB56B266DD34300EC3F28 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		843AB5FA266E2AAE00EC3F28 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		8448C2392679F9F4005955D4 /* UserCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCredential.swift; sourceTree = "<group>"; };
+		8448C23C2679FA90005955D4 /* KeychainStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStorage.swift; sourceTree = "<group>"; };
+		8448C23E2679FA97005955D4 /* KeychainKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainKeys.swift; sourceTree = "<group>"; };
+		8448C2402679FAFF005955D4 /* UserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
+		8448C2422679FB1E005955D4 /* UserSessionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionProvider.swift; sourceTree = "<group>"; };
 		846483FF267757D100233656 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		84A0AB5E26706AC4005EBF9A /* CredentialTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialTextField.swift; sourceTree = "<group>"; };
 		84A0AB6426708954005EBF9A /* R.swift+Typealias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "R.swift+Typealias.swift"; sourceTree = "<group>"; };
@@ -174,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				8423B97026734D8C0000036F /* AuthToken.swift */,
+				8448C2392679F9F4005955D4 /* UserCredential.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -298,6 +309,7 @@
 		843AB4CE266DC9F000EC3F28 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				8448C23B2679FA7F005955D4 /* Keychain */,
 				84D07497267321EC009CFE4C /* Network */,
 			);
 			path = Services;
@@ -322,6 +334,15 @@
 				843AB4D6266DCB5E00EC3F28 /* LoginPresenter.swift */,
 			);
 			path = Login;
+			sourceTree = "<group>";
+		};
+		8448C23B2679FA7F005955D4 /* Keychain */ = {
+			isa = PBXGroup;
+			children = (
+				8448C23C2679FA90005955D4 /* KeychainStorage.swift */,
+				8448C23E2679FA97005955D4 /* KeychainKeys.swift */,
+			);
+			path = Keychain;
 			sourceTree = "<group>";
 		};
 		846483FE267757C500233656 /* ErrorView */ = {
@@ -424,6 +445,8 @@
 			children = (
 				84D074A12673228A009CFE4C /* Base */,
 				84D0749F2673227C009CFE4C /* BaseAPI.swift */,
+				8448C2422679FB1E005955D4 /* UserSessionProvider.swift */,
+				8448C2402679FAFF005955D4 /* UserSession.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -743,11 +766,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8448C23A2679F9F4005955D4 /* UserCredential.swift in Sources */,
 				842C6F80266DC5AA0017E1CD /* AppDelegate.swift in Sources */,
 				84D074A326732296009CFE4C /* API.swift in Sources */,
+				8448C2412679FAFF005955D4 /* UserSession.swift in Sources */,
 				84D0748F26732128009CFE4C /* Environment.swift in Sources */,
 				84A0AB5F26706AC4005EBF9A /* CredentialTextField.swift in Sources */,
 				84D074A02673227C009CFE4C /* BaseAPI.swift in Sources */,
+				8448C2432679FB1E005955D4 /* UserSessionProvider.swift in Sources */,
 				842C6F82266DC5AA0017E1CD /* SceneDelegate.swift in Sources */,
 				843AB4DB266DCB5E00EC3F28 /* LoginPresenter.swift in Sources */,
 				84648400267757D100233656 /* ErrorView.swift in Sources */,
@@ -766,7 +792,9 @@
 				84D0748926731FFC009CFE4C /* R.generated.swift in Sources */,
 				843AB4D8266DCB5E00EC3F28 /* LoginModule.swift in Sources */,
 				8423B97126734D8C0000036F /* AuthToken.swift in Sources */,
+				8448C23F2679FA97005955D4 /* KeychainKeys.swift in Sources */,
 				8423B97426734E6A0000036F /* AuthenticationService.swift in Sources */,
+				8448C23D2679FA90005955D4 /* KeychainStorage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SurveyApp/Models/Authentication/AuthToken.swift
+++ b/SurveyApp/Models/Authentication/AuthToken.swift
@@ -5,39 +5,23 @@
 //  Created by Chananchida F. on 6/11/21.
 //
 
-struct AuthAttributes: Codable {
+struct Session: Codable {
     
     enum CodingKeys: String, CodingKey {
-        case accessToken = "access_token"
-        case tokenType = "token_type"
-        case expiresIn = "expires_in"
-        case refreshToken = "refresh_token"
-        case createdAt = "created_at"
-    }
-    
-    let accessToken: String?
-    let tokenType: String?
-    let expiresIn: Int?
-    let refreshToken: String?
-    let createdAt: Int?
-}
-
-struct AuthData: Codable {
-    
-    enum CodingKeys: String, CodingKey {
-        case id, type, attributes
+        case id, type
+        case userCredential = "attributes"
     }
     
     let id: Int?
     let type: String?
-    let attributes: AuthAttributes?
+    let userCredential: UserCredential?
 }
 
 struct AuthToken: Codable {
     
     enum CodingKeys: String, CodingKey {
-        case data
+        case session = "data"
     }
     
-    let data: AuthData?
+    let session: Session?
 }

--- a/SurveyApp/Models/Authentication/UserCredential.swift
+++ b/SurveyApp/Models/Authentication/UserCredential.swift
@@ -1,0 +1,25 @@
+//
+//  UserCredential.swift
+//  SurveyApp
+//
+//  Created by Chananchida F. on 6/16/21.
+//
+
+import Foundation
+
+struct UserCredential: Codable {
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+        case createdAt = "created_at"
+    }
+    
+    let accessToken: String?
+    let tokenType: String?
+    let expiresIn: Int?
+    let refreshToken: String?
+    let createdAt: TimeInterval?
+}

--- a/SurveyApp/Services/Keychain/KeychainKeys.swift
+++ b/SurveyApp/Services/Keychain/KeychainKeys.swift
@@ -1,0 +1,15 @@
+//
+//  KeychainKeys.swift
+//  SurveyApp
+//
+//  Created by Chananchida F. on 6/16/21.
+//
+
+protocol KeychainKeys {}
+
+extension KeychainKeys {
+
+    static var credential: KeychainStorage.Key<UserCredential> {
+        KeychainStorage.Key(key: "userCredential")
+    }
+}

--- a/SurveyApp/Services/Keychain/KeychainStorage.swift
+++ b/SurveyApp/Services/Keychain/KeychainStorage.swift
@@ -1,0 +1,47 @@
+//
+//  KeychainStorage.swift
+//  SurveyApp
+//
+//  Created by Chananchida F. on 6/16/21.
+//
+
+import KeychainAccess
+
+protocol KeychainStorageProtocol: AnyObject {
+
+    func get<T: Decodable>(_ key: KeychainStorage.Key<T>) throws -> T?
+    func set<T: Encodable>(_ value: T?, for key: KeychainStorage.Key<T>) throws
+
+    func remove<T>(_ key: KeychainStorage.Key<T>) throws
+}
+
+final class KeychainStorage: KeychainStorageProtocol {
+
+    struct Key<T>: KeychainKeys {
+
+        let key: String
+    }
+
+    static let `default` = KeychainStorage(service: Bundle.main.bundleIdentifier ?? "")
+
+    private let keychain: Keychain
+
+    private init(service: String) {
+        keychain = Keychain(service: service)
+    }
+
+    func set<T: Encodable>(_ value: T?, for key: Key<T>) throws {
+        guard let value = value else { return try remove(key) }
+        try keychain.set(JSONEncoder().encode(value), key: key.key)
+    }
+
+    func get<T: Decodable>(_ key: Key<T>) throws -> T? {
+        try keychain
+            .getData(key.key)
+            .map { try JSONDecoder().decode(T.self, from: $0) }
+    }
+
+    func remove<T>(_ key: KeychainStorage.Key<T>) throws {
+        try keychain.remove(key.key)
+    }
+}

--- a/SurveyApp/Services/Network/API/BaseAPI.swift
+++ b/SurveyApp/Services/Network/API/BaseAPI.swift
@@ -10,6 +10,12 @@ import Alamofire
 
 final class BaseAPI: API {
     
+    private let userSession: UserSessionProtocol
+
+    init(userSession: UserSessionProtocol) {
+        self.userSession = userSession
+    }
+    
     func url(forEndpoint endpoint: String, baseURL: String) -> String {
         let url = URL(string: baseURL)?.appendingPathComponent(endpoint, isDirectory: false)
         return url?.absoluteString ?? baseURL

--- a/SurveyApp/Services/Network/API/UserSession.swift
+++ b/SurveyApp/Services/Network/API/UserSession.swift
@@ -1,0 +1,27 @@
+//
+//  UserSession.swift
+//  SurveyApp
+//
+//  Created by Chananchida F. on 6/16/21.
+//
+
+import Foundation
+
+protocol UserSessionProtocol: AnyObject {
+
+    var userCredential: UserCredential? { get set }
+}
+
+final class UserSession: UserSessionProtocol {
+
+    private let keychain: KeychainStorageProtocol
+
+    var userCredential: UserCredential? {
+        get { try? keychain.get(.credential) }
+        set { try? keychain.set(newValue, for: .credential) }
+    }
+
+    init(keychain: KeychainStorageProtocol) {
+        self.keychain = keychain
+    }
+}

--- a/SurveyApp/Services/Network/API/UserSessionProvider.swift
+++ b/SurveyApp/Services/Network/API/UserSessionProvider.swift
@@ -1,0 +1,29 @@
+//
+//  UserSessionProvider.swift
+//  SurveyApp
+//
+//  Created by Chananchida F. on 6/16/21.
+//
+
+import Foundation
+
+protocol UserSessionProviderProtocol: AnyObject {
+
+    var userSession: UserSession? { get }
+    var isLoggedIn: Bool { get }
+}
+
+final class UserSessionProvider: UserSessionProviderProtocol {
+
+    public static let shared = UserSessionProvider()
+
+    var userSession: UserSession?
+
+    public var isLoggedIn: Bool {
+        userSession?.userCredential?.refreshToken != nil
+    }
+
+    public func clearCredentials() {
+        userSession?.userCredential = nil
+    }
+}

--- a/SurveyApp/Services/Network/Factory/NetworkServiceFactory.swift
+++ b/SurveyApp/Services/Network/Factory/NetworkServiceFactory.swift
@@ -10,7 +10,16 @@ import Foundation
 final class NetworkServiceFactory {
     
     static let shared = NetworkServiceFactory()
-    let api = BaseAPI()
+    let api: API
+
+    init() {
+        let keychain = KeychainStorage.default
+
+        let userSession = UserSession(keychain: keychain)
+        UserSessionProvider.shared.userSession = userSession
+
+        api = BaseAPI(userSession: userSession)
+    }
     
     func createAuthenticationService() -> AuthenticationServiceProtocol {
         AuthenticationService(api: api, baseURL: Constants.Network.baseUrl)


### PR DESCRIPTION
Resolves https://github.com/llleyelll/ic-surveys-ios/issues/38

## What happened 👀

- Implement `Keychain`
- Implement `UserSession`
- Refactor `AuthToken`
 
## Insight 📝

- The base API service don't have user session for manage user credential yet. I implement this so that it can use user credential when make an API call.
- Add `KeychainAccess` library
- Store and access local storage with keychain
 
## Proof Of Work 📹

Example call:
```Swift
let service = NetworkServiceFactory.shared.createAuthenticationService()
service.authenticateEmail(email: "email", password: "password") { result in
    switch result {
    case .success(let authToken):
        UserSessionProvider.shared.userSession?.userCredential = authToken.session?.userCredential
        dump(UserSessionProvider.shared.userSession?.userCredential) // just to show result
    case .failure(let error):
        dump(error)
    }
}
```
![Screen Shot 2021-06-16 at 3 42 12 PM](https://user-images.githubusercontent.com/45258998/122196173-32ba1d00-cec1-11eb-9e5c-090509c5fe1c.png)
