### PR TITLE
[54][Bug] Wrong id type for API response object

### DIFF
--- a/SurveyApp/Models/Authentication/AuthToken.swift
+++ b/SurveyApp/Models/Authentication/AuthToken.swift
@@ -12,7 +12,7 @@ struct Session: Codable {
         case userCredential = "attributes"
     }
     
-    let id: Int?
+    let id: String?
     let type: String?
     let userCredential: UserCredential?
 }


### PR DESCRIPTION
Resolves https://github.com/llleyelll/ic-surveys-ios/issues/54

## What happened 👀

- Change type of id in `Session` object to be `String` instead of `Int`
 
## Proof Of Work 📹

![2021-06-22 13 34 48](https://user-images.githubusercontent.com/45258998/122875592-aabf9180-d35e-11eb-9ee4-f12e33f30bc3.gif)

