### PR TITLE
[Bug] Github Actions failed to install Crashlytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -26,8 +26,6 @@ target 'SurveyApp' do
   pod 'AlamofireImage'
   pod 'AlamofireNetworkActivityLogger', '~> 3.4'
   pod 'KeychainAccess'
-  
-  pod 'Crashlytics'
 
   target 'SurveyAppTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,6 @@ PODS:
     - Alamofire (~> 5.4)
   - AlamofireNetworkActivityLogger (3.4.0):
     - Alamofire (~> 5.4.0)
-  - Crashlytics (3.14.0):
-    - Fabric (~> 1.10.2)
-  - Fabric (1.10.2)
   - KeychainAccess (4.2.2)
   - Keys (1.0.1)
   - Nimble (9.2.0)
@@ -36,7 +33,6 @@ DEPENDENCIES:
   - Alamofire
   - AlamofireImage
   - AlamofireNetworkActivityLogger (~> 3.4)
-  - Crashlytics
   - KeychainAccess
   - Keys (from `Pods/CocoaPodsKeys`)
   - Nimble
@@ -53,8 +49,6 @@ SPEC REPOS:
     - Alamofire
     - AlamofireImage
     - AlamofireNetworkActivityLogger
-    - Crashlytics
-    - Fabric
     - KeychainAccess
     - Nimble
     - OHHTTPStubs
@@ -81,8 +75,6 @@ SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
   AlamofireImage: 34a2d90b0e5fe6a5605f85ae4b7b01e784c60192
   AlamofireNetworkActivityLogger: 162ab8aee00e6267a4304d7cc134e13ccfe3bcc5
-  Crashlytics: 9220f5bc89e7a618df411b4f639389dbfb0e03d2
-  Fabric: ea977e3cd9c20425516d3dafd3bf8c941c51223f
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
@@ -95,6 +87,6 @@ SPEC CHECKSUMS:
   Sourcery: 43d8addc35ca31c2ab331cfd34b02421fa53bb7f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 0ab947cb1776a17de2da4fdabaf9601488010770
+PODFILE CHECKSUM: 6934cda25e08c3897ebbb0d0b7f4ff262ffad788
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
https://github.com/llleyelll/ic-surveys-ios/issues/79

## What happened 👀

- Remove Crashlytics temporarily.
 
## Insight 📝

- Crashlytics needs to delete temporarily since it causes the build failed and all PRs will be unable to run tests.
- This crash may be caused by Github Actions. If this issue can be self-solved in the future we can add Crashlytics back to the project.
 
## Proof Of Work 📹

![Screen Shot 2021-07-09 at 10 47 41 AM](https://user-images.githubusercontent.com/45258998/125020465-17e35e80-e0a3-11eb-9d12-3a3dfc1ffc13.png)

